### PR TITLE
feat: add AI-DLC MCP Server pattern (all-phases)

### DIFF
--- a/all-phases/all-phases-aidlc-mcp/PROMPTS_CUSTOMIZATION.md
+++ b/all-phases/all-phases-aidlc-mcp/PROMPTS_CUSTOMIZATION.md
@@ -1,0 +1,222 @@
+# Customizing AI-DLC Prompts
+
+The AI-DLC MCP server uses phase-specific prompts to guide AI assistants through the development lifecycle. These prompts are defined in `src/aidlc_mcp/prompts.py` and can be customized for your organization's needs.
+
+## ⚠️ Important Warning
+
+Modifying prompts may change the AI-DLC workflow behavior and could break the intended phase progression. Always test modifications with a sample project before deploying to production use.
+
+## Prompt Structure
+
+Each phase prompt (both full and abbreviated) includes:
+
+1. **Role Definition**: Sets the AI's expertise and perspective
+2. **Planning Requirements**: Defines how to create execution plans with checkboxes
+3. **Approval Gates**: Specifies when human approval is required (every phase)
+4. **Task Description**: Details what needs to be accomplished
+5. **Deliverables**: Specifies output files and locations
+6. **Phase Transition**: Instructions for moving to the next phase
+
+## Prompt Sets
+
+The server maintains two sets of prompts:
+
+### Full Flow Prompts
+- `DISCOVERY_0_1` — Full system analysis (Brownfield only)
+- `INCEPTION_1_1` — User stories creation
+- `INCEPTION_1_2` — Unit grouping
+- `CONSTRUCTION_2_1` — Domain model design (DDD)
+- `CONSTRUCTION_2_2` — Implementation
+- `CONSTRUCTION_2_3` — Deployment
+
+### Abbreviated Flow Prompts
+- `DISCOVERY_0_1_LITE` — Targeted analysis of affected area
+- `INCEPTION_1_1_LITE` — User stories as single unit (includes regression criteria)
+- `CONSTRUCTION_2_2_LITE` — Implement following existing patterns
+- `OPERATIONS_3_1` — Validate and regression check
+- `DEPLOYMENT_2_3_LITE` — Assess existing deploy, adapt if needed
+
+## Available Variables
+
+Prompts support variable substitution:
+
+- `{use-case}`: User's project description from `aidlc_start_project`
+- `{current-feature}`: Feature name from `.aidlc/` directory structure
+
+## Customization Examples
+
+### 1. Change Role Expertise Level
+
+**Before:**
+```python
+INCEPTION_1_1 = """Your Role: You are an expert product manager..."""
+```
+
+**After:**
+```python
+INCEPTION_1_1 = """Your Role: You are a senior product owner with 10+ years of Agile experience..."""
+```
+
+### 2. Add Organization-Specific Standards
+
+**Before:**
+```python
+Your Task: Build user stories for the high-level requirement...
+```
+
+**After:**
+```python
+Your Task: Build user stories following our company's Agile standards (see https://wiki.company.com/agile-standards). 
+Ensure all stories include:
+- Business value statement
+- Acceptance criteria in Given-When-Then format
+- Estimated story points
+Build user stories for the high-level requirement...
+```
+
+### 3. Modify Approval Gates
+
+**Before:**
+```python
+**STOP and wait for my explicit approval before proceeding.**
+```
+
+**After (for trusted environments):**
+```python
+**Present the plan for review. You may proceed after 30 seconds if no objections.**
+```
+
+### 4. Change Deliverable Formats
+
+**Before:**
+```python
+Create the analysis in .aidlc/{current-feature}/discovery/current_state_analysis.md file.
+```
+
+**After:**
+```python
+Create the analysis in .aidlc/{current-feature}/discovery/current_state_analysis.md file.
+Also generate a summary presentation in .aidlc/{current-feature}/discovery/executive_summary.pptx.
+```
+
+### 5. Add Security Review Steps
+
+**Before (Construction 2.2):**
+```python
+Include a final step in your plan to review deliverables for completeness and quality...
+```
+
+**After:**
+```python
+Include a final step in your plan to review deliverables for completeness and quality...
+Add a security review step to check for:
+- Input validation
+- Authentication/authorization
+- Sensitive data handling
+- Dependency vulnerabilities
+```
+
+## Testing Your Changes
+
+After modifying prompts:
+
+1. **Verify Import**:
+   ```bash
+   python -c "from src.aidlc_mcp.prompts import PROMPTS; print(f'{len(PROMPTS)} prompts loaded')"
+   ```
+
+2. **Test with Sample Project**:
+   ```bash
+   # Start a test project in an empty directory
+   mkdir /tmp/aidlc-test && cd /tmp/aidlc-test
+   # Use your MCP client to run: aidlc_start_project
+   ```
+
+3. **Verify Phase Transitions**:
+   - Ensure each phase completes successfully
+   - Check that `aidlc_get_phase_prompt` returns the correct next phase
+   - Verify `aidlc_set_phase_status` updates tracking correctly
+
+## Common Pitfalls
+
+### ❌ Breaking Phase Transitions
+
+**Problem**: Removing phase transition instructions
+```python
+# DON'T remove this line:
+After completing all steps, automatically get the next prompt using aidlc_get_phase_prompt...
+```
+
+**Solution**: Keep phase transition instructions intact or update them carefully.
+
+### ❌ Invalid Variable Names
+
+**Problem**: Using undefined variables
+```python
+# This will fail - {project-name} is not defined:
+Your Task: Build {project-name} according to...
+```
+
+**Solution**: Only use `{use-case}` and `{current-feature}`.
+
+### ❌ Inconsistent Tool Names
+
+**Problem**: Using old tool names
+```python
+# Old tool names (don't use):
+aidlc_update_plan  # Now: aidlc_update_project_plan
+aidlc_update_phase # Now: aidlc_set_phase_status
+aidlc_get_prompt   # Now: aidlc_get_phase_prompt
+```
+
+**Solution**: Use current tool names from the MCP server.
+
+## Best Practices
+
+1. **Keep Approval Gates**: Human oversight prevents costly mistakes
+2. **Maintain Deliverable Structure**: Other phases depend on specific file locations
+3. **Test Incrementally**: Change one prompt at a time and test
+4. **Document Changes**: Add comments explaining why you modified prompts
+5. **Version Control**: Commit prompt changes separately for easy rollback
+
+## Phase-Specific Considerations
+
+### Discovery (0.1 / 0.1-lite)
+- Full: Critical for Brownfield projects, analyzes entire system
+- Lite: Targeted analysis of only the affected area — don't over-analyze
+- Sets context for all subsequent phases
+
+### Inception (1.1, 1.2 / 1.1-lite)
+- Full: User stories drive the entire project; unit grouping affects team structure
+- Lite: Single unit, includes regression criteria; no decomposition step
+- Changes here cascade to construction phases
+
+### Construction (2.1, 2.2, 2.3 / 2.2-lite)
+- Full: Domain design influences implementation; implementation stays in `.aidlc/` until deployment
+- Lite: Skips domain modeling; writes directly to source following existing patterns
+
+### Operations (3.1 — abbreviated only)
+- Validates changes against acceptance criteria
+- Checks for regressions before deployment
+- Documents validation results for deployment phase
+
+### Deployment (2.3 / 2.3-lite)
+- Full: Creates new deployment procedures from scratch
+- Lite: Assesses existing deployment, only modifies if the changes require it
+
+## Getting Help
+
+- 🐛 [Report Issues](https://gitlab.aws.dev/jordthur/aidlc-mcp/-/issues)
+- 💡 [Request Features](https://gitlab.aws.dev/jordthur/aidlc-mcp/-/issues)
+- 📖 [Main Documentation](README.md)
+
+## Contributing
+
+If you develop useful prompt customizations, consider contributing them back:
+
+1. Fork the repository
+2. Create a feature branch
+3. Add your customization as an optional variant
+4. Submit a merge request with examples and use cases
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for details.

--- a/all-phases/all-phases-aidlc-mcp/README.md
+++ b/all-phases/all-phases-aidlc-mcp/README.md
@@ -1,0 +1,209 @@
+# AI-DLC MCP Server
+
+## Introduction
+
+This pattern provides a **Model Context Protocol (MCP) server** that implements the [AI-Driven Development Life Cycle (AI-DLC)](https://aws.amazon.com/blogs/devops/ai-driven-development-life-cycle/) methodology as structured tool calls. Instead of relying on AI agents to interpret markdown rules, the server enforces the workflow programmatically — with validated inputs, phase gate transitions, persistent state tracking, and centralized prompt customization.
+
+This is a **complementary approach** to the rules-based [awslabs/aidlc-workflows](https://github.com/awslabs/aidlc-workflows). Both can be used independently or together:
+
+| | Rules-based (aidlc-workflows) | Server-based (this pattern) |
+|---|---|---|
+| **How it works** | Agent reads markdown context files | Agent calls MCP tools with typed parameters |
+| **Phase enforcement** | Agent interprets rules | Server validates transitions programmatically |
+| **Cross-session state** | Agent re-reads rules each session | `current_phase.json` persists across sessions |
+| **Prompt customization** | Edit scattered markdown files | Single `prompts.py` module |
+| **Dependencies** | None (copy files) | Python 3.10+, `mcp` package |
+
+### Key Features
+
+- **Full & Abbreviated Flows**: Full cycle for complex features (all phases from inception through deployment); abbreviated for bug fixes and minor enhancements (streamlined phases, no unit decomposition or domain modeling). Both Greenfield and Brownfield default to the full flow — abbreviated (lite) is only used when explicitly requested via `flowType: "abbreviated"`
+- **Intelligent Project Detection**: Auto-detects Greenfield vs Brownfield projects
+- **Human-in-the-Loop Approval**: Agents request approval before executing plans
+- **Security Hardened**: Path traversal prevention, input sanitization, error sanitization, symlink rejection
+- **Resume Support**: Pick up where you left off across chat sessions
+
+## Solution Architecture
+
+```
+┌─────────────────┐
+│   MCP Client    │  (Kiro CLI, Q CLI, Claude Desktop, Cursor, Cline)
+│  (AI Assistant) │
+└────────┬────────┘
+         │ MCP Protocol (stdio)
+         ▼
+┌─────────────────┐     ┌──────────────────┐
+│  AI-DLC MCP     │────▶│  prompts.py      │
+│  Server         │     │  (customizable)  │
+│  (server.py)    │     └──────────────────┘
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│  .aidlc/        │  Project state, plans, artifacts, backups
+│  (persistent)   │
+└─────────────────┘
+```
+
+### How It Works
+
+1. **Start**: Agent calls `aidlc_start_project` — detects project type, creates `.aidlc/` structure, selects flow
+2. **Guide**: Agent calls `aidlc_get_phase_prompt` — gets phase-specific instructions with sanitized use case
+3. **Plan**: Agent creates plan with checkboxes, asks clarifying questions, requests human approval
+4. **Execute**: Agent follows approved plan step-by-step, updates plan via `aidlc_update_project_plan`
+5. **Progress**: Agent calls `aidlc_set_phase_status` to advance — server validates the transition
+6. **Integrate**: Agent calls `aidlc_integrate_code` to move generated code into the project (with backup + logging)
+
+### MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `aidlc_start_project` | Initialize AI-DLC project, detect Greenfield/Brownfield, select flow |
+| `aidlc_get_phase_prompt` | Get phase-specific prompt with use case interpolation |
+| `aidlc_get_next_phase` | Get the next recommended phase based on current project state |
+| `aidlc_set_phase_status` | Advance phase with validated transitions |
+| `aidlc_update_project_plan` | Update plan with clarifying question answers |
+| `aidlc_request_phase_approval` | Request mandatory human approval before executing a plan |
+| `aidlc_integrate_code` | Copy generated code into project with dest validation, backup, logging |
+
+## Repository Structure
+
+```
+all-phases-aidlc-mcp/
+├── README.md                    # This file
+├── pyproject.toml               # Python package configuration
+├── PROMPTS_CUSTOMIZATION.md     # Guide to customizing phase prompts
+├── src/
+│   └── aidlc_mcp/
+│       ├── __init__.py
+│       ├── server.py            # MCP server with security controls
+│       └── prompts.py           # Phase-specific prompt templates
+└── tests/
+    ├── test_flows.py            # Flow and phase transition tests
+    └── test_security.py         # Security control tests
+```
+
+## Prerequisites
+
+- **Python** 3.10 or higher
+- **pip** (Python package manager)
+- **MCP-compatible client**: Kiro CLI, Amazon Q CLI, Claude Desktop, Cursor, Cline, or any MCP client
+
+## Deployment Instructions
+
+### Step 1: Install the MCP Server
+
+```bash
+cd all-phases/all-phases-aidlc-mcp
+pip install -e .
+```
+
+### Step 2: Configure Your MCP Client
+
+Add to your MCP client configuration:
+
+**Kiro CLI** (`~/.kiro/settings/mcp.json`):
+```json
+{
+  "mcpServers": {
+    "aidlc": {
+      "command": "python",
+      "args": ["-m", "aidlc_mcp.server"]
+    }
+  }
+}
+```
+
+**Claude Desktop** (`claude_desktop_config.json`):
+```json
+{
+  "mcpServers": {
+    "aidlc": {
+      "command": "python",
+      "args": ["-m", "aidlc_mcp.server"]
+    }
+  }
+}
+```
+
+**Cursor** (`.cursor/mcp.json`):
+```json
+{
+  "mcpServers": {
+    "aidlc": {
+      "command": "python",
+      "args": ["-m", "aidlc_mcp.server"]
+    }
+  }
+}
+```
+
+### Step 3: Start Using AI-DLC
+
+Tell your AI agent what you want to build:
+
+> "I want to start an AI-DLC project to build a task management API"
+
+The agent will automatically call the MCP tools to initialize the project, guide you through phases, and request approvals at each gate.
+
+## Prompt Customization
+
+All phase prompts are centralized in a single `prompts.py` module, making it easy to customize the AI-DLC workflow for your organization's standards, frameworks, or domain-specific requirements. See [PROMPTS_CUSTOMIZATION.md](PROMPTS_CUSTOMIZATION.md) for the full guide.
+
+Key customization options:
+- Modify phase-specific instructions (e.g., require specific design patterns or testing frameworks)
+- Add organization-specific context to every phase prompt
+- Inject project-specific guidance via the `useCase` parameter
+- Add custom phases to the sequence
+
+This is a key differentiator from the rules-based approach — instead of editing scattered markdown files and hoping the agent interprets your changes consistently, you modify a single Python module and every tool call reflects the change deterministically.
+
+## Test
+
+### Verify Installation
+
+```bash
+# Server should start and wait for MCP messages on stdin
+python -m aidlc_mcp.server
+# Press Ctrl+C to exit
+```
+
+### Verify with MCP Client
+
+1. Start your MCP client
+2. Ask: "What AI-DLC tools do you have?" (should list 7 tools)
+3. Create a new directory and say: "Start an AI-DLC project to build a hello world app"
+4. Verify the agent creates `.aidlc/` and begins the inception phase
+
+## Clean Up
+
+```bash
+# Uninstall the package
+pip uninstall aidlc-mcp
+
+# Remove MCP configuration entry from your client config file
+
+# Remove AI-DLC artifacts from a project
+rm -rf .aidlc/
+```
+
+## Security
+
+This server includes security hardening:
+
+- **Path traversal prevention**: Rejects `..` in all path parameters
+- **Input sanitization**: Type checking, enum validation, required field enforcement
+- **Use case sanitization**: 1000 character limit, control character stripping
+- **Error sanitization**: Generic errors to client, details to stderr
+- **Symlink rejection**: `integrate_code` rejects symlink destinations
+- **Resource limits**: 10K file cap on filesystem scanning
+- **Pinned dependency**: `mcp~=1.16.0`
+
+See [CONTRIBUTING](../../CONTRIBUTING.md) for more information.
+
+## License
+
+This library is licensed under the MIT-0 License. See the [LICENSE](../../LICENSE) file.
+
+## Disclaimer
+
+The solution architecture sample code is provided without any guarantees, and you're not recommended to use it for production-grade workloads. The intention is to provide content to build and learn. Be sure of reading the licensing terms.

--- a/all-phases/all-phases-aidlc-mcp/pyproject.toml
+++ b/all-phases/all-phases-aidlc-mcp/pyproject.toml
@@ -1,0 +1,35 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "aidlc-mcp"
+version = "1.0.0"
+description = "AI-Driven Development Life Cycle MCP Server"
+readme = "README.md"
+requires-python = ">=3.10"
+license = {text = "MIT-0"}
+keywords = ["mcp", "ai-dlc", "model-context-protocol", "ai-development"]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Code Generators",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
+]
+dependencies = [
+    "mcp~=1.16.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/aws-samples/sample-ai-powered-sdlc-patterns-with-aws"
+Repository = "https://github.com/aws-samples/sample-ai-powered-sdlc-patterns-with-aws"
+
+[project.scripts]
+aidlc-mcp = "aidlc_mcp.server:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/aidlc_mcp"]

--- a/all-phases/all-phases-aidlc-mcp/src/aidlc_mcp/prompts.py
+++ b/all-phases/all-phases-aidlc-mcp/src/aidlc_mcp/prompts.py
@@ -1,0 +1,257 @@
+"""
+AI-DLC Phase Prompts
+
+⚠️ WARNING: Modifying these prompts may change the AI-DLC workflow behavior
+and could break the intended phase progression. Edit with caution.
+
+These prompts guide AI assistants through each phase of the AI-DLC methodology.
+Each prompt includes:
+- Role definition for the AI
+- Planning requirements with approval gates
+- Task description with deliverables
+- Phase transition instructions
+
+Variables available for substitution:
+- {use-case}: User's project description
+- {current-feature}: Feature name from .aidlc directory
+
+## Customization Guide
+
+To customize prompts for your organization:
+
+1. **Modify Role Definitions**: Change the expertise level or focus area
+   Example: "expert product manager" → "senior product owner with Agile experience"
+
+2. **Adjust Planning Requirements**: Add/remove steps in the planning process
+   Example: Add "Include security review step" to construction phases
+
+3. **Change Deliverable Formats**: Modify output file formats or locations
+   Example: Change .md files to .txt or add additional documentation
+
+4. **Update Approval Gates**: Modify when human approval is required
+   Example: Remove approval gates for faster iteration in trusted environments
+
+5. **Add Organization-Specific Context**: Include company standards or tools
+   Example: "Use our internal design system documented at..."
+
+After modifications, test with a sample project to ensure phase transitions work correctly.
+"""
+
+DISCOVERY_0_1 = """Your Role: You are an expert system analyst and software architect tasked with analyzing the existing codebase.
+
+Plan for the work ahead and write your steps in an md file (analysis_plan.md) with checkboxes for each step in the plan. Include research/analysis steps, execution steps, and validation/review steps. If any step needs my clarification, add a note in the step to get my confirmation. Include a final step in your plan to review deliverables for completeness and quality before marking as done. Do not make critical decisions on your own. After creating the plan, ask me any clarifying questions one at a time directly in our conversation (don't use tools for questions). Once I answer all your questions, update the plan with my answers using aidlc_update_project_plan, then call `aidlc_request_phase_approval` with the plan title and steps to request my approval. **STOP and wait for my explicit approval before proceeding — do NOT execute any plan steps until I approve.** After I approve, execute the plan one step at a time. Once you finish each step, mark the checkboxes as done in the plan.
+
+**CRITICAL: Check for Discovery Context**
+Before starting, check if there is a discovery/ folder in the current feature directory (.aidlc/{current-feature}/discovery/). If it exists, read and reference the discovery analysis files to understand the existing codebase architecture.
+
+Your Task: Analyze the existing software application in the current directory. Document the current state including architecture, technology stack, components, data models, APIs, deployment setup, and areas for improvement. Create the analysis in .aidlc/{current-feature}/discovery/current_state_analysis.md file.
+
+**After completing analysis, use `aidlc_set_phase_status` to set phase to "discovery-0.1-ready" and call `aidlc_request_phase_approval` to request my approval before proceeding.**
+
+After completing all steps, automatically get the next prompt using aidlc_get_phase_prompt with phase "inception-1.1" to continue the AI-DLC methodology."""
+
+INCEPTION_1_1 = """Your Role: You are an expert product manager and are tasked with creating well-defined user stories as mentioned in the Task section below.
+
+Plan for the work ahead and write your steps in an md file (stories_plan.md) with checkboxes for each step in the plan. Include research/analysis steps, execution steps, and validation/review steps. If any step needs my clarification, add a note in the step to get my confirmation. Include a final step in your plan to review deliverables for completeness and quality before marking as done. Do not make critical decisions on your own. After creating the plan, ask me any clarifying questions one at a time directly in our conversation (don't use tools for questions). Once I answer all your questions, update the plan with my answers using aidlc_update_project_plan, then call `aidlc_request_phase_approval` with the plan title and steps to request my approval. **STOP and wait for my explicit approval before proceeding — do NOT execute any plan steps until I approve.** After I approve, execute the plan one step at a time. Once you finish each step, mark the checkboxes as done in the plan.
+
+**CRITICAL: Check for Discovery Context**
+Before starting, check if there is a discovery/ folder in the current feature directory (.aidlc/{current-feature}/discovery/). If it exists, read and reference the discovery analysis files to understand the existing codebase architecture when creating user stories.
+
+Your Task: Build user stories for the high-level requirement as described here: {use-case}
+
+Create an .aidlc/{current-feature}/inception/ directory for the stories_plan.md file and write the user stories to user_stories.md in the .aidlc/{current-feature}/inception/ directory.
+
+**After creating user_stories.md, use `aidlc_set_phase_status` to set phase to "inception-1.1-ready" and call `aidlc_request_phase_approval` to request my approval before proceeding.**
+
+After completing all steps, automatically get the next prompt using aidlc_get_phase_prompt with phase "inception-1.2" to continue the AI-DLC methodology."""
+
+INCEPTION_1_2 = """Your Role: You are an expert software architect and are tasked with grouping the user stories into multiple units that can be built independently as mentioned in the Task section below.
+
+Plan for the work ahead and write your steps in an md file (units_plan.md) with checkboxes for each step in the plan. If any step needs my clarification, add a note in the step to get my confirmation. Do not make critical decisions on your own. After creating the plan, ask me any clarifying questions one at a time directly in our conversation (don't use tools for questions). Once I answer all your questions, update the plan with my answers using aidlc_update_project_plan, then call `aidlc_request_phase_approval` with the plan title and steps to request my approval. **STOP and wait for my explicit approval before proceeding — do NOT execute any plan steps until I approve.** After I approve, execute the plan one step at a time. Once you finish each step, mark the checkboxes as done in the plan.
+
+**CRITICAL: Check for Discovery Context**
+Before starting, check if there is a discovery/ folder in the current feature directory (.aidlc/{current-feature}/discovery/). If it exists, read and reference the discovery analysis files to understand the existing codebase architecture when grouping user stories into units.
+
+Your Task: Refer to the user stories in .aidlc/{current-feature}/inception/user_stories.md file. Group the user stories into multiple units that can be built independently. Each unit contains highly cohesive user stories that can be built by a single team. The units must be loosely coupled with each other. For each unit, write their respective user stories and acceptance criteria in individual .md files in the .aidlc/{current-feature}/inception/units/ folder. Ensure each unit clearly identifies both backend functionality and frontend UI requirements. Do not start the technical systems design yet.
+
+**After creating all unit files, use `aidlc_set_phase_status` to set phase to "inception-1.2-ready" and call `aidlc_request_phase_approval` to request my approval before proceeding.**
+
+After completing all steps, automatically get the next prompt using aidlc_get_phase_prompt with phase "construction-2.1" to continue the AI-DLC methodology."""
+
+CONSTRUCTION_2_1 = """Your Role: You are an expert software architect and are tasked with designing the domain model using Domain Driven Design for a unit of the software system as mentioned in the Task section below.
+
+**CRITICAL: Check for Discovery Context**
+Before starting, check if there is a discovery/ folder in the current feature directory (.aidlc/{current-feature}/discovery/). If it exists, read and reference the discovery analysis files to understand the existing system architecture, technology stack, and constraints when designing the technical solution.
+
+Plan for the work ahead and write your steps in an md file (domain_design_plan.md) with checkboxes for each step in the plan. Include research/analysis steps, execution steps, and validation/review steps. If any step needs my clarification, add a note in the step to get my confirmation. Include a final step in your plan to review deliverables for completeness and quality before marking as done. Do not make critical decisions on your own. After creating the plan, ask me any clarifying questions one at a time directly in our conversation (don't use tools for questions). Once I answer all your questions, update the plan with my answers using aidlc_update_project_plan, then call `aidlc_request_phase_approval` with the plan title and steps to request my approval. **STOP and wait for my explicit approval before proceeding — do NOT execute any plan steps until I approve.** After I approve, execute the plan one step at a time. Once you finish each step, mark the checkboxes as done in the plan.
+
+Your Task: Refer to the units in .aidlc/{current-feature}/inception/units/ folder, each md file represents a software unit with the corresponding user stories. Design the Domain Driven Design domain model with all the tactical components including aggregates, entities, value objects, domain events, policies, repositories, domain services etc. Create the design details in .aidlc/{current-feature}/construction/{unit name}/domain_model.md file for each unit.
+
+**After creating all domain models, use `aidlc_set_phase_status` to set phase to "construction-2.1-ready" and call `aidlc_request_phase_approval` to request my approval before proceeding.**
+
+After completing all steps, automatically get the next prompt using aidlc_get_phase_prompt with phase "construction-2.2" to continue the AI-DLC methodology."""
+
+CONSTRUCTION_2_2 = """Your Role: You are an expert software engineer and are tasked with creating a plan to implement a highly scalable, event-driven system according to a Domain Driven Design domain model as mentioned in the Task section below.
+
+**CRITICAL: Check for Discovery Context**
+Before starting, check if there is a discovery/ folder in the current feature directory (.aidlc/{current-feature}/discovery/). If it exists, read and reference the discovery analysis files to understand the existing codebase, technology stack, and coding patterns when implementing the solution.
+
+Plan for the work ahead and write your steps in an md file (tasks_plan.md) with checkboxes for each step in the plan. Include research/analysis steps, execution steps, and validation/review steps. If any step needs my clarification, add a note in the step to get my confirmation. Include a final step in your plan to review deliverables for completeness and quality before marking as done. Do not make critical decisions on your own. After creating the plan, ask me any clarifying questions one at a time directly in our conversation (don't use tools for questions). Once I answer all your questions, update the plan with my answers using aidlc_update_project_plan, then call `aidlc_request_phase_approval` with the plan title and steps to request my approval. **STOP and wait for my explicit approval before proceeding — do NOT execute any plan steps until I approve.** After I approve, execute the plan one step at a time. Once you finish each step, mark the checkboxes as done in the plan.
+
+Your Task: Refer to .aidlc/{current-feature}/construction/units for the defined units of work, .aidlc/{current-feature}/construction/{unit name}/domain_model.md file for the domain model. Generate a very simple and intuitive implementation for the bounded context. Assume the repositories and the event stores are in-memory. Generate the classes in respective individual files but keep them in the .aidlc/{current-feature}/construction/{unit name}/ directory. Create a simple demo script that can be run locally to verify the implementation.
+
+**IMPORTANT:** Write all implementation files in the appropriate unit folders within .aidlc/{current-feature}/construction/{unit name}/ - do NOT create files in the project root yet. The deployment phase (construction-2.3) will handle integrating your code into the main project.
+
+**After completing all implementation, use `aidlc_set_phase_status` to set phase to "construction-2.2-ready" and call `aidlc_request_phase_approval` to request my approval before proceeding.**
+
+After completing all steps, automatically get the next prompt using aidlc_get_phase_prompt with phase "construction-2.3" to continue the AI-DLC methodology."""
+
+CONSTRUCTION_2_3 = """Your Role: You are an experienced Cloud Architect and are tasked with creating deployment procedures as mentioned in the Task section below.
+
+Plan for the work ahead and write your steps in an md file (deployment_plan.md) with checkboxes for each step in the plan. Include research/analysis steps, execution steps, and validation/review steps. If any step needs my clarification, add a note in the step to get my confirmation. Include a final step in your plan to review deliverables for completeness and quality before marking as done. Do not make critical decisions on your own. After creating the plan, ask me any clarifying questions one at a time directly in our conversation (don't use tools for questions). Once I answer all your questions, update the plan with my answers using aidlc_update_project_plan, then call `aidlc_request_phase_approval` with the plan title and steps to request my approval. **STOP and wait for my explicit approval before proceeding — do NOT execute any plan steps until I approve.** After I approve, execute the plan one step at a time. Once you finish each step, mark the checkboxes as done in the plan.
+
+Your Task: Refer to units in the .aidlc/{current-feature}/inception/units/ folder, the domain models and code in the .aidlc/{current-feature}/construction/ folder, and the source code in src/. Complete the following:
+- Generate an end-to-end plan for deployment of the backend on AWS cloud using [CloudFormation, CDK, Terraform].
+- Document all the pre-requisites for the deployment, if any.
+
+Once I approve the plan:
+- Follow the best practice of clean, simple, explainable coding.
+- All output code goes in the .aidlc/{current-feature}/deployment/ folder.
+- Validate that the generated code works as intended, by creating a validation plan, generate a validation report.
+- Review the validation report and fix all identified issues, update the validation report.
+
+**After completing deployment procedures, use `aidlc_set_phase_status` to set phase to "construction-2.3-ready" and call `aidlc_request_phase_approval` to request my approval before proceeding.**
+
+After approval, use `aidlc_integrate_code` to move the generated code from .aidlc/ into the main project structure."""
+
+# --- Abbreviated Brownfield Prompts (bug fixes / minor enhancements) ---
+
+DISCOVERY_0_1_LITE = """Your Role: You are an expert system analyst tasked with performing a targeted analysis of the existing codebase related to a specific bug fix or minor enhancement.
+
+Plan for the work ahead and write your steps in an md file (analysis_plan.md) with checkboxes for each step in the plan. Include research/analysis steps, execution steps, and validation/review steps. If any step needs my clarification, add a note in the step to get my confirmation. Include a final step in your plan to review deliverables for completeness and quality before marking as done. Do not make critical decisions on your own. After creating the plan, ask me any clarifying questions one at a time directly in our conversation (don't use tools for questions). Once I answer all your questions, update the plan with my answers using aidlc_update_project_plan, then call `aidlc_request_phase_approval` with the plan title and steps to request my approval. **STOP and wait for my explicit approval before proceeding — do NOT execute any plan steps until I approve.** After I approve, execute the plan one step at a time. Once you finish each step, mark the checkboxes as done in the plan.
+
+Your Task: Perform a targeted analysis of the existing codebase related to this issue/enhancement: {use-case}
+
+Focus your analysis on:
+- The specific files, components, and modules affected by this change
+- Dependencies and interactions of the affected components
+- Existing patterns, conventions, and coding standards used in the codebase
+- Potential impact areas and regression risks
+- Current test coverage for the affected area (if any)
+
+Do NOT analyze the entire system — stay focused on the area relevant to this change.
+
+Create the analysis in .aidlc/{current-feature}/discovery/targeted_analysis.md file.
+
+**After completing analysis, use `aidlc_set_phase_status` to set phase to "discovery-0.1-lite-ready" and call `aidlc_request_phase_approval` to request my approval before proceeding.**
+
+After completing all steps, automatically get the next prompt using aidlc_get_phase_prompt with phase "inception-1.1-lite" to continue the AI-DLC methodology."""
+
+INCEPTION_1_1_LITE = """Your Role: You are an expert product manager tasked with creating user stories for a bug fix or minor enhancement.
+
+Plan for the work ahead and write your steps in an md file (stories_plan.md) with checkboxes for each step in the plan. If any step needs my clarification, add a note in the step to get my confirmation. Do not make critical decisions on your own. After creating the plan, ask me any clarifying questions one at a time directly in our conversation (don't use tools for questions). Once I answer all your questions, update the plan with my answers using aidlc_update_project_plan, then call `aidlc_request_phase_approval` with the plan title and steps to request my approval. **STOP and wait for my explicit approval before proceeding — do NOT execute any plan steps until I approve.** After I approve, execute the plan one step at a time. Once you finish each step, mark the checkboxes as done in the plan.
+
+**CRITICAL: Reference Discovery Context**
+Read and reference the targeted analysis in .aidlc/{current-feature}/discovery/targeted_analysis.md to understand the affected area, existing patterns, and constraints.
+
+Your Task: Build user stories for this bug fix or minor enhancement: {use-case}
+
+For each user story, ensure acceptance criteria includes:
+- Functional requirements (what the fix/change does)
+- UI/UX requirements if applicable (what the user sees and interacts with)
+- Non-functional requirements (performance, accessibility, responsiveness, etc.)
+- Regression criteria (what existing behavior must NOT change)
+
+This is a single unit of work — do not decompose into multiple units. Write all user stories to .aidlc/{current-feature}/inception/user_stories.md.
+
+**After creating user_stories.md, use `aidlc_set_phase_status` to set phase to "inception-1.1-lite-ready" and call `aidlc_request_phase_approval` to request my approval before proceeding.**
+
+After completing all steps, automatically get the next prompt using aidlc_get_phase_prompt with phase "construction-2.2-lite" to continue the AI-DLC methodology."""
+
+CONSTRUCTION_2_2_LITE = """Your Role: You are an expert software engineer tasked with implementing a bug fix or minor enhancement following existing codebase patterns.
+
+Plan for the work ahead and write your steps in an md file (tasks_plan.md) with checkboxes for each step in the plan. Include research/analysis steps, execution steps, and validation/review steps. If any step needs my clarification, add a note in the step to get my confirmation. Include a final step in your plan to review deliverables for completeness and quality before marking as done. Do not make critical decisions on your own. After creating the plan, ask me any clarifying questions one at a time directly in our conversation (don't use tools for questions). Once I answer all your questions, update the plan with my answers using aidlc_update_project_plan, then call `aidlc_request_phase_approval` with the plan title and steps to request my approval. **STOP and wait for my explicit approval before proceeding — do NOT execute any plan steps until I approve.** After I approve, execute the plan one step at a time. Once you finish each step, mark the checkboxes as done in the plan.
+
+**CRITICAL: Reference Previous Phases**
+- Read .aidlc/{current-feature}/discovery/targeted_analysis.md for the codebase analysis
+- Read .aidlc/{current-feature}/inception/user_stories.md for requirements and acceptance criteria
+
+Your Task: Implement the changes to satisfy all user stories and acceptance criteria.
+
+Guidelines:
+- Follow existing code patterns, conventions, and directory structure
+- Keep changes minimal and focused — do not refactor unrelated code
+- Ensure all acceptance criteria are met, including regression criteria
+- Write changes directly to the appropriate source files in the project
+- Document what was changed and why in .aidlc/{current-feature}/construction/changes_summary.md
+
+**After completing implementation, use `aidlc_set_phase_status` to set phase to "construction-2.2-lite-ready" and call `aidlc_request_phase_approval` to request my approval before proceeding.**
+
+After completing all steps, automatically get the next prompt using aidlc_get_phase_prompt with phase "operations-3.1" to continue the AI-DLC methodology."""
+
+OPERATIONS_3_1 = """Your Role: You are an expert QA engineer tasked with validating a bug fix or minor enhancement.
+
+Plan for the work ahead and write your steps in an md file (validation_plan.md) with checkboxes for each step in the plan. Include validation steps, regression checks, and documentation steps. If any step needs my clarification, add a note in the step to get my confirmation. Include a final step in your plan to review deliverables for completeness and quality before marking as done. Do not make critical decisions on your own. After creating the plan, ask me any clarifying questions one at a time directly in our conversation (don't use tools for questions). Once I answer all your questions, update the plan with my answers using aidlc_update_project_plan, then call `aidlc_request_phase_approval` with the plan title and steps to request my approval. **STOP and wait for my explicit approval before proceeding — do NOT execute any plan steps until I approve.** After I approve, execute the plan one step at a time. Once you finish each step, mark the checkboxes as done in the plan.
+
+**CRITICAL: Reference Previous Phases**
+- Read .aidlc/{current-feature}/discovery/targeted_analysis.md for impact areas and regression risks
+- Read .aidlc/{current-feature}/inception/user_stories.md for acceptance criteria
+- Read .aidlc/{current-feature}/construction/changes_summary.md for what was changed
+
+Your Task: Validate the implementation against all acceptance criteria and check for regressions.
+
+Validation should cover:
+- Verify each acceptance criterion from the user stories is met
+- Run existing tests to check for regressions
+- Test edge cases identified in the targeted analysis
+- Verify the fix/enhancement works as expected in a local environment
+- Document any issues found and their resolution
+
+Create the validation report in .aidlc/{current-feature}/operations/validation_report.md.
+
+**After completing validation, use `aidlc_set_phase_status` to set phase to "operations-3.1-ready" and call `aidlc_request_phase_approval` to request my approval before proceeding.**
+
+After completing all steps, automatically get the next prompt using aidlc_get_phase_prompt with phase "deployment-2.3-lite" to continue the AI-DLC methodology."""
+
+DEPLOYMENT_2_3_LITE = """Your Role: You are an experienced Cloud Architect tasked with assessing and executing deployment for a bug fix or minor enhancement.
+
+Plan for the work ahead and write your steps in an md file (deployment_plan.md) with checkboxes for each step in the plan. If any step needs my clarification, add a note in the step to get my confirmation. Do not make critical decisions on your own. After creating the plan, ask me any clarifying questions one at a time directly in our conversation (don't use tools for questions). Once I answer all your questions, update the plan with my answers using aidlc_update_project_plan, then call `aidlc_request_phase_approval` with the plan title and steps to request my approval. **STOP and wait for my explicit approval before proceeding — do NOT execute any plan steps until I approve.** After I approve, execute the plan one step at a time. Once you finish each step, mark the checkboxes as done in the plan.
+
+**CRITICAL: Reference Previous Phases**
+- Read .aidlc/{current-feature}/discovery/targeted_analysis.md for existing deployment setup
+- Read .aidlc/{current-feature}/construction/changes_summary.md for what was changed
+- Read .aidlc/{current-feature}/operations/validation_report.md for validation results
+
+Your Task: Assess the existing deployment process and determine if changes are needed.
+
+Step 1 - Deployment Assessment:
+- Locate and analyze the existing deployment configuration (CloudFormation, CDK, Terraform, CI/CD pipelines, scripts, etc.)
+- Determine if the code changes require any deployment changes (new resources, config changes, environment variables, IAM permissions, etc.)
+- Document findings in .aidlc/{current-feature}/deployment/deployment_assessment.md
+
+Step 2 - Based on assessment:
+- **If deployment changes ARE needed**: Document the required changes in the deployment plan, request approval, then implement the changes and redeploy
+- **If NO deployment changes are needed**: Report that no deployment changes are required, request approval to proceed, then execute redeployment using the existing process
+
+Document the deployment outcome in .aidlc/{current-feature}/deployment/deployment_report.md.
+
+**After completing deployment, use `aidlc_set_phase_status` to set phase to "deployment-2.3-lite-ready" and call `aidlc_request_phase_approval` to request my approval.**
+
+After approval, use `aidlc_integrate_code` to move any generated deployment code from .aidlc/ into the main project structure."""
+
+# Prompt mapping
+PROMPTS = {
+    # Full flow
+    'discovery-0.1': DISCOVERY_0_1,
+    'inception-1.1': INCEPTION_1_1,
+    'inception-1.2': INCEPTION_1_2,
+    'construction-2.1': CONSTRUCTION_2_1,
+    'construction-2.2': CONSTRUCTION_2_2,
+    'construction-2.3': CONSTRUCTION_2_3,
+    # Abbreviated flow
+    'discovery-0.1-lite': DISCOVERY_0_1_LITE,
+    'inception-1.1-lite': INCEPTION_1_1_LITE,
+    'construction-2.2-lite': CONSTRUCTION_2_2_LITE,
+    'operations-3.1': OPERATIONS_3_1,
+    'deployment-2.3-lite': DEPLOYMENT_2_3_LITE,
+}

--- a/all-phases/all-phases-aidlc-mcp/src/aidlc_mcp/server.py
+++ b/all-phases/all-phases-aidlc-mcp/src/aidlc_mcp/server.py
@@ -1,0 +1,932 @@
+#!/usr/bin/env python3
+"""AI-DLC MCP Server - Python Implementation
+
+This server implements the AI-Driven Development Life Cycle methodology
+through the Model Context Protocol, providing structured guidance for
+AI-assisted software development.
+"""
+
+import json
+import os
+import shutil
+from pathlib import Path
+from datetime import datetime
+from typing import Optional, Dict, List, Any
+import sys
+
+# Import MCP SDK
+try:
+    from mcp.server import Server
+    from mcp.server.stdio import stdio_server
+    from mcp.types import Tool, TextContent
+except ImportError:
+    print("Error: MCP SDK not installed. Run: pip install mcp", file=sys.stderr)
+    sys.exit(1)
+
+# Import prompts
+from .prompts import PROMPTS
+
+# AI-DLC Phase Progression
+PHASE_SEQUENCE_FULL = [
+    "discovery-0.1",
+    "inception-1.1",
+    "inception-1.2",
+    "construction-2.1",
+    "construction-2.2",
+    "construction-2.3"
+]
+
+PHASE_SEQUENCE_ABBREVIATED = [
+    "discovery-0.1-lite",
+    "inception-1.1-lite",
+    "construction-2.2-lite",
+    "operations-3.1",
+    "deployment-2.3-lite"
+]
+
+# Legacy alias for backward compatibility
+PHASE_SEQUENCE = PHASE_SEQUENCE_FULL
+
+# Note: Phase prompts are now in prompts.py for easier customization
+
+# Helper functions
+def get_next_phase(current_phase: str, flow_type: str = "full") -> Optional[str]:
+    """Get the next phase in the sequence based on flow type."""
+    sequence = PHASE_SEQUENCE_ABBREVIATED if flow_type == "abbreviated" else PHASE_SEQUENCE_FULL
+    try:
+        current_index = sequence.index(current_phase)
+        if current_index == len(sequence) - 1:
+            return None
+        return sequence[current_index + 1]
+    except ValueError:
+        return None
+
+
+def get_flow_type(project_path: str) -> str:
+    """Read flow type from current_phase.json. Defaults to 'full'."""
+    phase_file = Path(project_path) / '.aidlc' / 'current_phase.json'
+    if phase_file.exists():
+        try:
+            with open(phase_file, 'r') as f:
+                ft = json.load(f).get('flowType', 'full')
+                if ft in ('full', 'abbreviated'):
+                    return ft
+        except (json.JSONDecodeError, IOError):
+            pass
+    return 'full'
+
+def has_existing_code(project_path: str) -> bool:
+    """Check if project has existing code files."""
+    if not os.path.exists(project_path):
+        return False
+    
+    code_extensions = ['.js', '.ts', '.py', '.java', '.go', '.rs', '.cpp', '.c', '.cs', '.php', '.rb', '.swift', '.kt']
+    config_files = ['package.json', 'requirements.txt', 'Cargo.toml', 'pom.xml', 'go.mod', 'Gemfile', 'composer.json']
+    files_scanned = [0]
+    MAX_SCAN_FILES = 10000
+    
+    def scan_directory(dir_path: str, depth: int = 0) -> bool:
+        if depth > 3 or files_scanned[0] >= MAX_SCAN_FILES:
+            return False
+        
+        try:
+            for item in os.listdir(dir_path):
+                files_scanned[0] += 1
+                if files_scanned[0] >= MAX_SCAN_FILES:
+                    return False
+                if item.startswith('.') and item not in ['.env', '.aidlc']:
+                    continue
+                if item in ['node_modules', '__pycache__', 'target']:
+                    continue
+                
+                item_path = os.path.join(dir_path, item)
+                
+                if os.path.isfile(item_path):
+                    ext = os.path.splitext(item)[1]
+                    if ext in code_extensions or item in config_files:
+                        return True
+                elif os.path.isdir(item_path):
+                    if scan_directory(item_path, depth + 1):
+                        return True
+        except (PermissionError, OSError):
+            pass
+        
+        return False
+    
+    return scan_directory(project_path)
+
+def detect_current_phase(project_path: str) -> Optional[str]:
+    """Detect current phase from current_phase.json."""
+    aidlc_path = Path(project_path) / '.aidlc'
+    if not aidlc_path.exists():
+        return None
+    
+    phase_file = aidlc_path / 'current_phase.json'
+    if phase_file.exists():
+        try:
+            with open(phase_file, 'r') as f:
+                phase_data = json.load(f)
+                if not isinstance(phase_data, dict):
+                    return None
+                phase = phase_data.get('currentPhase')
+                if not phase or not isinstance(phase, str):
+                    return None
+                # Build valid set (including -ready variants) inline to avoid circular ref
+                all_phases = set(PHASE_SEQUENCE_FULL + PHASE_SEQUENCE_ABBREVIATED)
+                all_valid = all_phases | {p + '-ready' for p in all_phases}
+                if phase not in all_valid:
+                    return None
+                return phase
+        except (json.JSONDecodeError, IOError):
+            pass
+    
+    return None
+
+def detect_feature_name(project_path: str) -> Optional[str]:
+    """Detect feature name from .aidlc directory."""
+    aidlc_path = Path(project_path) / '.aidlc'
+    if not aidlc_path.exists():
+        return None
+    
+    try:
+        feature_dirs = [d for d in aidlc_path.iterdir() if d.is_dir()]
+        if feature_dirs:
+            return feature_dirs[0].name
+    except (PermissionError, OSError):
+        pass
+    
+    return None
+
+def detect_project_state(project_path: str) -> Dict[str, Any]:
+    """Detect project state (Greenfield/Brownfield)."""
+    aidlc_exists = (Path(project_path) / '.aidlc').exists()
+    has_code = has_existing_code(project_path)
+    
+    if aidlc_exists:
+        phase = detect_current_phase(project_path)
+        if phase:
+            # Existing AI-DLC project — resume regardless of code presence
+            return {'type': 'Brownfield' if has_code else 'Greenfield', 'phase': phase, 'action': 'resume'}
+        else:
+            # .aidlc exists but no phase — stale, treat as fresh start
+            return {'type': 'Brownfield' if has_code else 'Greenfield', 'phase': None, 'action': 'start'}
+    
+    # No .aidlc directory
+    if has_code:
+        return {'type': 'Brownfield', 'phase': None, 'action': 'start'}
+    
+    return {'type': 'Greenfield', 'phase': None, 'action': 'start'}
+
+# --- Security helpers ---
+
+def validate_project_path(path: str, must_exist: bool = True) -> str:
+    """Validate and resolve project path. Raises ValueError on invalid input."""
+    if not path or not isinstance(path, str):
+        raise ValueError("projectPath must be a non-empty string")
+    resolved = str(Path(path).resolve())
+    if '..' in Path(path).parts:
+        raise ValueError("projectPath must not contain '..' path traversal")
+    if must_exist:
+        if not os.path.exists(resolved):
+            raise ValueError(f"projectPath does not exist: {resolved}")
+        if not os.path.isdir(resolved):
+            raise ValueError(f"projectPath is not a directory: {resolved}")
+    return resolved
+
+
+import re as _re
+
+def sanitize_use_case(text: str, max_length: int = 1000) -> tuple:
+    """Sanitize use case text. Returns (sanitized_text, was_truncated)."""
+    if not isinstance(text, str):
+        return ('', False)
+    # Strip control characters (keep printable + common whitespace)
+    cleaned = _re.sub(r'[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]', '', text).strip()
+    was_truncated = len(cleaned) > max_length
+    return (cleaned[:max_length], was_truncated)
+
+
+def validate_plan_file_path(path: str) -> str:
+    """Validate plan file path resolves inside a .aidlc/ directory."""
+    if not path or not isinstance(path, str):
+        raise ValueError("planFile must be a non-empty string")
+    resolved = Path(path).resolve()
+    if '..' in Path(path).parts:
+        raise ValueError("planFile must not contain '..' path traversal")
+    parts = resolved.parts
+    if '.aidlc' not in parts:
+        raise ValueError("planFile must be inside a .aidlc/ directory")
+    if not resolved.exists():
+        raise ValueError(f"planFile does not exist: {resolved}")
+    return str(resolved)
+
+
+VALID_PHASES = set(PHASE_SEQUENCE_FULL + PHASE_SEQUENCE_ABBREVIATED)
+VALID_PHASES_WITH_READY = VALID_PHASES | {p + '-ready' for p in VALID_PHASES}
+VALID_FLOW_TYPES = {'full', 'abbreviated', 'auto'}
+VALID_PROJECT_TYPES = {'Greenfield', 'Brownfield'}
+
+
+def validate_required_string(args: dict, key: str) -> str:
+    """Validate a required string parameter. Raises ValueError if missing/empty/not-string."""
+    val = args.get(key)
+    if not val or not isinstance(val, str):
+        raise ValueError(f"'{key}' must be a non-empty string")
+    return val
+
+
+# MCP Server
+app = Server("aidlc-mcp")
+
+@app.list_tools()
+async def list_tools() -> List[Tool]:
+    """List available AI-DLC tools."""
+    return [
+        Tool(
+            name="aidlc_start_project",
+            description="Initialize AI-DLC project structure. Use when: starting a new AI-DLC workflow in an empty or existing codebase. Automatically detects Greenfield (new code) vs Brownfield (existing code). Defaults to full flow for both. Use abbreviated flow ONLY for simple bug fixes, typos, minor config changes, or small enhancements that don't require architectural decisions or unit decomposition.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "projectPath": {
+                        "type": "string",
+                        "description": "Absolute path to project directory (example: /Users/name/projects/my-app)"
+                    },
+                    "useCase": {
+                        "type": "string",
+                        "description": "What you want to build or fix (example: 'REST API for task management' or 'fix login timeout bug')"
+                    },
+                    "projectType": {
+                        "type": "string",
+                        "enum": ["Greenfield", "Brownfield"],
+                        "description": "Optional override for auto-detection. Greenfield = new project with no existing code, Brownfield = existing codebase to enhance"
+                    },
+                    "flowType": {
+                        "type": "string",
+                        "enum": ["full", "abbreviated", "auto"],
+                        "description": "Flow type: 'full' (default) = complete AI-DLC cycle with all phases including unit decomposition and domain modeling. Use for new features, major enhancements, migrations, or anything requiring architectural decisions. 'abbreviated' = streamlined lite phases for simple bug fixes, typos, minor config changes, or small enhancements that follow existing patterns without new architecture. 'auto' = defaults to full. Default: auto"
+                    }
+                },
+                "required": ["projectPath", "useCase"]
+            }
+        ),
+        Tool(
+            name="aidlc_get_next_phase",
+            description="Check current AI-DLC project status and get next phase to execute. Use when: resuming work on an existing AI-DLC project or after completing a phase. ALWAYS call this FIRST before other tools to understand project state.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "projectPath": {
+                        "type": "string",
+                        "description": "Absolute path to AI-DLC project directory (example: /Users/name/projects/my-app)"
+                    }
+                },
+                "required": ["projectPath"]
+            }
+        ),
+        Tool(
+            name="aidlc_get_phase_prompt",
+            description="Get detailed instructions for executing a specific AI-DLC phase. Use when: aidlc_get_next_phase tells you which phase to execute next. Returns complete prompt with planning steps, approval gates, and deliverables for that phase.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "phase": {
+                        "type": "string",
+                        "enum": ["discovery-0.1", "inception-1.1", "inception-1.2", "construction-2.1", "construction-2.2", "construction-2.3", "discovery-0.1-lite", "inception-1.1-lite", "construction-2.2-lite", "operations-3.1", "deployment-2.3-lite"],
+                        "description": "AI-DLC phase: Full flow: discovery-0.1, inception-1.1, inception-1.2, construction-2.1, construction-2.2, construction-2.3. Abbreviated flow: discovery-0.1-lite, inception-1.1-lite, construction-2.2-lite, operations-3.1, deployment-2.3-lite."
+                    },
+                    "useCase": {
+                        "type": "string",
+                        "description": "Your use case description to inject into the prompt (example: 'task management app')"
+                    },
+                    "projectPath": {
+                        "type": "string",
+                        "description": "Project path for validation (example: /Users/name/projects/my-app)"
+                    }
+                },
+                "required": ["phase"]
+            }
+        ),
+        Tool(
+            name="aidlc_update_project_plan",
+            description="Update project plan file with answers to clarifying questions. Use when: you've asked the user clarifying questions and received answers that need to be incorporated into the plan before requesting approval.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "planFile": {
+                        "type": "string",
+                        "description": "Absolute path to plan markdown file (example: /Users/name/projects/my-app/.aidlc/feature/inception/stories_plan.md)"
+                    },
+                    "updates": {
+                        "type": "string",
+                        "description": "Updates to incorporate into the plan (example: 'User confirmed PostgreSQL database and REST API architecture')"
+                    },
+                    "title": {
+                        "type": "string",
+                        "description": "Title for approval request (example: 'Updated User Stories Plan with Database Choice')"
+                    }
+                },
+                "required": ["planFile", "updates", "title"]
+            }
+        ),
+        Tool(
+            name="aidlc_request_phase_approval",
+            description="Request human approval before proceeding with plan execution. Use when: you've created a plan and need explicit approval before executing it. This is a required gate in the AI-DLC methodology.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string",
+                        "description": "Approval request title (example: 'User Stories Plan Ready for Review')"
+                    },
+                    "steps": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "List of plan steps to approve (example: ['Analyze requirements', 'Create user stories', 'Define acceptance criteria'])"
+                    }
+                },
+                "required": ["title", "steps"]
+            }
+        ),
+        Tool(
+            name="aidlc_set_phase_status",
+            description="Update current AI-DLC phase status after completing deliverables. Use when: you've finished all deliverables for a phase and are ready to mark it complete or ready for next phase.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "projectPath": {
+                        "type": "string",
+                        "description": "Project directory absolute path (example: /Users/name/projects/my-app)"
+                    },
+                    "phase": {
+                        "type": "string",
+                        "enum": ["discovery-0.1", "discovery-0.1-ready", "inception-1.1", "inception-1.1-ready", "inception-1.2", "inception-1.2-ready", "construction-2.1", "construction-2.1-ready", "construction-2.2", "construction-2.2-ready", "construction-2.3", "construction-2.3-ready", "discovery-0.1-lite", "discovery-0.1-lite-ready", "inception-1.1-lite", "inception-1.1-lite-ready", "construction-2.2-lite", "construction-2.2-lite-ready", "operations-3.1", "operations-3.1-ready", "deployment-2.3-lite", "deployment-2.3-lite-ready"],
+                        "description": "Phase status. Append '-ready' when phase is complete. Full flow: discovery-0.1, inception-1.1, inception-1.2, construction-2.1, construction-2.2, construction-2.3. Abbreviated flow: discovery-0.1-lite, inception-1.1-lite, construction-2.2-lite, operations-3.1, deployment-2.3-lite."
+                    },
+                    "feature": {
+                        "type": "string",
+                        "description": "Feature name (optional, auto-detected if not provided)"
+                    }
+                },
+                "required": ["projectPath", "phase"]
+            }
+        ),
+        Tool(
+            name="aidlc_integrate_code",
+            description="Move generated code from .aidlc staging area into main repository structure. Use when: construction-2.2 (implementation) or construction-2.3 (deployment) phases are complete. Behavior: Greenfield projects integrate both implementation and deployment code automatically. Brownfield projects integrate deployment code only (ask user before integrating implementation to avoid conflicts).",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "projectPath": {
+                        "type": "string",
+                        "description": "Project directory absolute path (example: /Users/name/projects/my-app)"
+                    },
+                    "feature": {
+                        "type": "string",
+                        "description": "Feature name to integrate (optional, auto-detected if not provided)"
+                    }
+                },
+                "required": ["projectPath"]
+            }
+        )
+    ]
+
+@app.call_tool()
+async def call_tool(name: str, arguments: Dict[str, Any]) -> List[TextContent]:
+    """Handle tool calls."""
+    try:
+        if name == "aidlc_start_project":
+            return await start_project(arguments)
+        elif name == "aidlc_get_next_phase":
+            return await get_next_phase_tool(arguments)
+        elif name == "aidlc_get_phase_prompt":
+            return await get_prompt(arguments)
+        elif name == "aidlc_update_project_plan":
+            return await update_plan(arguments)
+        elif name == "aidlc_request_phase_approval":
+            return await request_approval(arguments)
+        elif name == "aidlc_set_phase_status":
+            return await update_phase(arguments)
+        elif name == "aidlc_integrate_code":
+            return await integrate_code(arguments)
+        else:
+            raise ValueError(f"Unknown tool: {name}")
+    except ValueError as e:
+        return [TextContent(type="text", text=f"❌ Validation error: {e}")]
+    except Exception as e:
+        print(f"Error in {name}: {type(e).__name__}: {e}", file=sys.stderr)
+        return [TextContent(type="text", text=f"❌ Operation failed: {type(e).__name__}. Check server logs for details.")]
+
+# Tool implementations (simplified for initial conversion)
+async def start_project(args: Dict[str, Any]) -> List[TextContent]:
+    """Initialize AI-DLC project."""
+    project_path = validate_project_path(args['projectPath'], must_exist=False)
+    use_case, use_case_truncated = sanitize_use_case(validate_required_string(args, 'useCase'))
+    flow_type = args.get('flowType', 'auto')
+    if flow_type not in VALID_FLOW_TYPES:
+        raise ValueError(f"flowType must be one of: {', '.join(VALID_FLOW_TYPES)}")
+    project_type_override = args.get('projectType')
+    if project_type_override and project_type_override not in VALID_PROJECT_TYPES:
+        raise ValueError(f"projectType must be one of: {', '.join(VALID_PROJECT_TYPES)}")
+    
+    # Detect project state
+    state = detect_project_state(project_path)
+    
+    # Determine flow type
+    if flow_type == 'auto':
+        # Both Greenfield and Brownfield default to full flow
+        # Abbreviated (lite) is only used when explicitly requested
+        flow_type = 'full'
+    
+    # Create .aidlc structure
+    aidlc_path = Path(project_path) / '.aidlc'
+    aidlc_path.mkdir(exist_ok=True)
+    
+    # Create feature directory
+    feature_name = use_case.lower().replace(' ', '-')[:50]
+    feature_path = aidlc_path / feature_name
+    feature_path.mkdir(exist_ok=True)
+    
+    # Create phase subdirectories based on flow type
+    if flow_type == 'abbreviated':
+        for subdir in ['discovery', 'inception', 'construction', 'operations', 'deployment']:
+            (feature_path / subdir).mkdir(exist_ok=True)
+    else:
+        for subdir in ['discovery', 'inception', 'inception/units', 'construction', 'deployment']:
+            (feature_path / subdir).mkdir(parents=True, exist_ok=True)
+    
+    # Determine initial phase based on flow type
+    if flow_type == 'abbreviated':
+        initial_phase = 'discovery-0.1-lite'
+    elif state['type'] == 'Brownfield':
+        initial_phase = 'discovery-0.1'
+    else:
+        initial_phase = 'inception-1.1'
+    
+    # Initialize current_phase.json
+    phase_file = aidlc_path / 'current_phase.json'
+    phase_data = {
+        'currentPhase': initial_phase,
+        'feature': feature_name,
+        'flowType': flow_type,
+        'lastUpdated': datetime.now().isoformat()
+    }
+    
+    with open(phase_file, 'w') as f:
+        json.dump(phase_data, f, indent=2)
+    
+    flow_label = "Abbreviated (bug fix / minor enhancement)" if flow_type == "abbreviated" else "Full AI-DLC"
+    truncation_warning = "\n\n⚠️ **Warning**: Your use case description was truncated to 1000 characters." if use_case_truncated else ""
+    
+    return [TextContent(
+        type="text",
+        text=f"✅ **AI-DLC Project Initialized**\n\nProject Type: {state['type']}\nFlow: {flow_label}\nFeature: {feature_name}\nStarting Phase: {initial_phase}\n\nUse `aidlc_get_next_phase` to continue.{truncation_warning}"
+    )]
+
+async def get_next_phase_tool(args: Dict[str, Any]) -> List[TextContent]:
+    """Get next phase information."""
+    project_path = validate_project_path(args.get('projectPath', '.'))
+    
+    current_phase = detect_current_phase(project_path)
+    flow_type = get_flow_type(project_path)
+    
+    if not current_phase:
+        return [TextContent(
+            type="text",
+            text="No AI-DLC project found. Use `aidlc_start_project` to initialize."
+        )]
+    
+    # Strip -ready suffix for phase lookup
+    phase_for_lookup = current_phase.replace('-ready', '')
+    next_phase = get_next_phase(phase_for_lookup, flow_type)
+    
+    if next_phase:
+        return [TextContent(
+            type="text",
+            text=f"Current Phase: {current_phase}\nFlow: {flow_type}\nNext Phase: {next_phase}\n\nUse `aidlc_get_prompt` with step=\"{next_phase}\" to continue."
+        )]
+    else:
+        return [TextContent(
+            type="text",
+            text=f"✅ All phases complete!\n\nCurrent Phase: {current_phase}\nFlow: {flow_type}"
+        )]
+
+async def get_prompt(args: Dict[str, Any]) -> List[TextContent]:
+    """Get prompt for a specific phase."""
+    phase = validate_required_string(args, 'phase')
+    if phase not in VALID_PHASES:
+        raise ValueError(f"phase must be one of: {', '.join(sorted(VALID_PHASES))}")
+    use_case = args.get('useCase', '')
+    if use_case:
+        use_case, _ = sanitize_use_case(use_case)
+    project_path = args.get('projectPath', '.')
+    if args.get('projectPath'):
+        project_path = validate_project_path(project_path)
+    
+    prompt = PROMPTS.get(phase, "Prompt not found for this phase.")
+    
+    if use_case:
+        prompt = prompt.replace('{use-case}', use_case)
+    
+    feature = detect_feature_name(project_path)
+    if feature:
+        prompt = prompt.replace('{current-feature}', feature)
+    
+    return [TextContent(type="text", text=prompt)]
+
+async def update_plan(args: Dict[str, Any]) -> List[TextContent]:
+    """Update plan file."""
+    plan_file = validate_plan_file_path(args['planFile'])
+    updates = validate_required_string(args, 'updates')
+    
+    # Read existing plan
+    with open(plan_file, 'r') as f:
+        content = f.read()
+    
+    # Append updates
+    updated_content = f"{content}\n\n## Updates\n\n{updates}"
+    
+    with open(plan_file, 'w') as f:
+        f.write(updated_content)
+    
+    return [TextContent(
+        type="text",
+        text=f"✅ Plan updated: {plan_file}"
+    )]
+
+async def request_approval(args: Dict[str, Any]) -> List[TextContent]:
+    """Request approval."""
+    title = validate_required_string(args, 'title')
+    steps = args.get('steps')
+    if not steps or not isinstance(steps, list) or not all(isinstance(s, str) for s in steps):
+        raise ValueError("'steps' must be a non-empty list of strings")
+    
+    steps_text = '\n'.join(f"- {step}" for step in steps)
+    
+    return [TextContent(
+        type="text",
+        text=f"📋 **Approval Required: {title}**\n\n{steps_text}\n\n⛔ WAITING FOR USER APPROVAL. Do NOT proceed until the user explicitly approves. Ask the user to review the plan above and confirm."
+    )]
+
+async def update_phase(args: Dict[str, Any]) -> List[TextContent]:
+    """Update current phase."""
+    project_path = validate_project_path(args['projectPath'])
+    phase = validate_required_string(args, 'phase')
+    if phase not in VALID_PHASES_WITH_READY:
+        raise ValueError(f"phase must be a valid AI-DLC phase or phase-ready value")
+    feature = args.get('feature')
+    
+    aidlc_path = Path(project_path) / '.aidlc'
+    phase_file = aidlc_path / 'current_phase.json'
+    
+    # Read existing data to preserve flowType
+    flow_type = get_flow_type(project_path)
+    
+    # Get feature name if not provided
+    if not feature:
+        feature_dirs = [d for d in aidlc_path.iterdir() if d.is_dir()]
+        if feature_dirs:
+            feature = feature_dirs[0].name
+    
+    phase_data = {
+        'currentPhase': phase,
+        'feature': feature,
+        'flowType': flow_type,
+        'lastUpdated': datetime.now().isoformat()
+    }
+    
+    with open(phase_file, 'w') as f:
+        json.dump(phase_data, f, indent=2)
+    
+    return [TextContent(
+        type="text",
+        text=f"""✅ **Phase Updated**
+
+Current phase: {phase}
+Feature: {feature}
+Updated: {phase_data['lastUpdated']}
+
+Use `aidlc_get_next_phase` to see what's next."""
+    )]
+
+def detect_project_structure(project_path: str) -> Dict[str, Any]:
+    """Detect project language, type, and structure."""
+    config_files = {
+        'package.json': {'language': 'JavaScript/TypeScript', 'type': 'Node.js'},
+        'requirements.txt': {'language': 'Python', 'type': 'Python'},
+        'setup.py': {'language': 'Python', 'type': 'Python'},
+        'pom.xml': {'language': 'Java', 'type': 'Maven'},
+        'build.gradle': {'language': 'Java', 'type': 'Gradle'},
+        'Cargo.toml': {'language': 'Rust', 'type': 'Rust'},
+        'go.mod': {'language': 'Go', 'type': 'Go'},
+        'Gemfile': {'language': 'Ruby', 'type': 'Ruby'}
+    }
+    
+    project_info = {'language': 'Unknown', 'type': 'Unknown', 'isGreenfield': True}
+    
+    for file, info in config_files.items():
+        if (Path(project_path) / file).exists():
+            project_info.update(info)
+            break
+    
+    # Check if Brownfield
+    project_info['isGreenfield'] = not has_existing_code(project_path)
+    
+    # Analyze structure
+    if not project_info['isGreenfield']:
+        project_info['structure'] = analyze_existing_structure(project_path)
+    else:
+        project_info['structure'] = get_best_practice_structure(project_info['type'])
+    
+    return project_info
+
+def analyze_existing_structure(project_path: str) -> Dict[str, Optional[str]]:
+    """Analyze existing project structure."""
+    structure = {
+        'models': None,
+        'services': None,
+        'controllers': None,
+        'handlers': None,
+        'utils': None,
+        'tests': None
+    }
+    
+    search_patterns = {
+        'models': ['models', 'model', 'domain', 'entities', 'entity'],
+        'services': ['services', 'service'],
+        'controllers': ['controllers', 'controller'],
+        'handlers': ['handlers', 'handler', 'routes', 'api'],
+        'utils': ['utils', 'util', 'helpers', 'helper', 'lib'],
+        'tests': ['tests', 'test', '__tests__', 'spec']
+    }
+    
+    items_scanned = [0]
+    MAX_SCAN = 10000
+
+    def scan_dir(dir_path: Path, depth: int = 0):
+        if depth > 3 or not dir_path.exists() or items_scanned[0] >= MAX_SCAN:
+            return
+        
+        try:
+            for item in dir_path.iterdir():
+                items_scanned[0] += 1
+                if items_scanned[0] >= MAX_SCAN:
+                    return
+                if item.name in ['.aidlc', 'node_modules', '.git']:
+                    continue
+                
+                if not item.is_dir():
+                    continue
+                
+                item_lower = item.name.lower()
+                for type_name, patterns in search_patterns.items():
+                    if any(p in item_lower for p in patterns) and not structure[type_name]:
+                        structure[type_name] = str(item.relative_to(project_path))
+                
+                scan_dir(item, depth + 1)
+        except Exception:
+            pass
+    
+    scan_dir(Path(project_path))
+    return structure
+
+def get_best_practice_structure(project_type: str) -> Dict[str, str]:
+    """Get best practice directory structure."""
+    structures = {
+        'Node.js': {
+            'models': 'src/models',
+            'services': 'src/services',
+            'controllers': 'src/controllers',
+            'handlers': 'src/handlers',
+            'utils': 'src/utils',
+            'tests': 'tests'
+        },
+        'Python': {
+            'models': 'src/models',
+            'services': 'src/services',
+            'controllers': 'src/controllers',
+            'handlers': 'src/handlers',
+            'utils': 'src/utils',
+            'tests': 'tests'
+        },
+        'Maven': {
+            'models': 'src/main/java/models',
+            'services': 'src/main/java/services',
+            'controllers': 'src/main/java/controllers',
+            'handlers': 'src/main/java/handlers',
+            'utils': 'src/main/java/utils',
+            'tests': 'src/test/java'
+        },
+        'Go': {
+            'models': 'internal/models',
+            'services': 'internal/services',
+            'controllers': 'internal/controllers',
+            'handlers': 'internal/handlers',
+            'utils': 'pkg/utils',
+            'tests': 'tests'
+        },
+        'Rust': {
+            'models': 'src/models',
+            'services': 'src/services',
+            'controllers': 'src/controllers',
+            'handlers': 'src/handlers',
+            'utils': 'src/utils',
+            'tests': 'tests'
+        }
+    }
+    
+    return structures.get(project_type, structures['Node.js'])
+
+def classify_file(filename: str, file_path: str) -> str:
+    """Classify file type based on name and content."""
+    lower = filename.lower()
+    
+    # Check filename patterns
+    if 'model' in lower or 'entity' in lower:
+        return 'models'
+    if 'service' in lower:
+        return 'services'
+    if 'controller' in lower:
+        return 'controllers'
+    if 'handler' in lower or 'route' in lower:
+        return 'handlers'
+    if 'util' in lower or 'helper' in lower:
+        return 'utils'
+    if 'test' in lower or 'spec' in lower:
+        return 'tests'
+    
+    # Check content
+    try:
+        with open(file_path, 'r') as f:
+            content = f.read()
+        if 'class' in content and 'Model' in content:
+            return 'models'
+        if 'Service' in content or 'service' in content:
+            return 'services'
+        if 'Controller' in content or 'controller' in content:
+            return 'controllers'
+        if 'handler' in content or 'Handler' in content:
+            return 'handlers'
+    except Exception:
+        pass
+    
+    return 'services'
+
+def get_destination_path(project_path: str, project_info: Dict, file_type: str, filename: str) -> str:
+    """Get destination path for file."""
+    structure = project_info['structure']
+    target_dir = structure.get(file_type) or structure.get('services') or 'src'
+    return str(Path(project_path) / target_dir / filename)
+
+def get_infrastructure_path(project_path: str) -> str:
+    """Get infrastructure directory path."""
+    infra_dirs = ['infrastructure', 'infra', 'cdk', 'terraform', 'cloudformation', 'iac']
+    
+    for dir_name in infra_dirs:
+        dir_path = Path(project_path) / dir_name
+        if dir_path.exists():
+            return str(dir_path)
+    
+    return str(Path(project_path) / 'infrastructure')
+
+async def integrate_code(args: Dict[str, Any]) -> List[TextContent]:
+    """Integrate code from .aidlc into project."""
+    project_path = validate_project_path(args['projectPath'])
+    feature = args.get('feature')
+    
+    aidlc_path = Path(project_path) / '.aidlc'
+    project_root = Path(project_path).resolve()
+    
+    def validate_dest(dest: Path):
+        """Ensure destination resolves within project root and is not a symlink."""
+        if dest.is_symlink():
+            raise ValueError(f"Destination is a symlink (rejected): {dest}")
+        resolved = dest.resolve()
+        if not str(resolved).startswith(str(project_root)):
+            raise ValueError(f"Destination escapes project root: {resolved}")
+        return resolved
+
+    def backup_if_exists(dest: Path):
+        """Backup existing file to .aidlc/backups/latest/ before overwriting."""
+        if dest.exists():
+            backup_dir = aidlc_path / 'backups' / 'latest'
+            backup_dir.mkdir(parents=True, exist_ok=True)
+            rel = dest.relative_to(project_root)
+            backup_dest = backup_dir / rel
+            backup_dest.parent.mkdir(parents=True, exist_ok=True)
+            if dest.is_dir():
+                if backup_dest.exists():
+                    shutil.rmtree(backup_dest)
+                shutil.copytree(dest, backup_dest)
+            else:
+                shutil.copy2(dest, backup_dest)
+
+    def log_operation(src: str, dest: str):
+        """Append to integration log."""
+        log_file = aidlc_path / 'integration.log'
+        with open(log_file, 'a') as f:
+            f.write(f"{datetime.now().isoformat()} COPY {src} -> {dest}\n")
+
+    # Get feature name
+    if not feature:
+        feature_dirs = [d for d in aidlc_path.iterdir() if d.is_dir() and d.name != 'backups']
+        if feature_dirs:
+            feature = feature_dirs[0].name
+    
+    if not feature:
+        raise ValueError('No feature found in .aidlc directory')
+    
+    # Clear previous backup
+    backup_latest = aidlc_path / 'backups' / 'latest'
+    if backup_latest.exists():
+        shutil.rmtree(backup_latest)
+    
+    feature_path = aidlc_path / feature
+    construction_path = feature_path / 'construction'
+    deployment_path = feature_path / 'deployment'
+    
+    # Detect project structure
+    project_info = detect_project_structure(project_path)
+    is_greenfield = project_info['isGreenfield']
+    moved_files = []
+    
+    # Move implementation files (only for Greenfield)
+    if is_greenfield and construction_path.exists():
+        for unit_dir in construction_path.iterdir():
+            if not unit_dir.is_dir():
+                continue
+            
+            for file in unit_dir.iterdir():
+                if file.suffix == '.md' or file.name.startswith('.') or file.name == '__pycache__':
+                    continue
+                
+                if file.is_file():
+                    file_type = classify_file(file.name, str(file))
+                    dest_path = Path(get_destination_path(project_path, project_info, file_type, file.name))
+                    validate_dest(dest_path)
+                    dest_path.parent.mkdir(parents=True, exist_ok=True)
+                    backup_if_exists(dest_path)
+                    shutil.copy2(file, dest_path)
+                    log_operation(str(file), str(dest_path))
+                    moved_files.append(str(dest_path.relative_to(project_path)))
+    
+    # Move deployment files
+    if deployment_path.exists():
+        infra_path = get_infrastructure_path(project_path)
+        Path(infra_path).mkdir(parents=True, exist_ok=True)
+        
+        for item in deployment_path.iterdir():
+            if item.name.startswith('.') or item.name == '__pycache__':
+                continue
+            
+            if item.is_file():
+                if item.suffix != '.md':
+                    dest_file = Path(infra_path) / item.name
+                    validate_dest(dest_file)
+                    backup_if_exists(dest_file)
+                    shutil.copy2(item, dest_file)
+                    log_operation(str(item), str(dest_file))
+                    moved_files.append(str(dest_file.relative_to(project_path)))
+            elif item.is_dir():
+                dest_dir = Path(infra_path) / item.name
+                validate_dest(dest_dir)
+                backup_if_exists(dest_dir)
+                if dest_dir.exists():
+                    shutil.rmtree(dest_dir)
+                shutil.copytree(item, dest_dir)
+                log_operation(str(item), str(dest_dir))
+                moved_files.append(str(dest_dir.relative_to(project_path)) + '/')
+    
+    files_list = '\n'.join(f"- {f}" for f in moved_files)
+    
+    integration_type = "Greenfield (implementation + deployment)" if is_greenfield else "Brownfield (deployment only)"
+    
+    return [TextContent(
+        type="text",
+        text=f"""✅ **Code Integration Complete!**
+
+Project Type: {project_info['type']} ({'Greenfield' if is_greenfield else 'Brownfield'})
+Integration: {integration_type}
+Language: {project_info['language']}
+
+Moved {len(moved_files)} items from `.aidlc/{feature}/` to your repository:
+
+{files_list}
+
+All planning artifacts remain in `.aidlc/{feature}/` for reference.
+
+Your code is now integrated and ready to use! 🚀"""
+    )]
+
+async def async_main():
+    """Async main entry point."""
+    async with stdio_server() as (read_stream, write_stream):
+        await app.run(read_stream, write_stream, app.create_initialization_options())
+
+def main():
+    """Sync entry point for console scripts."""
+    import asyncio
+    asyncio.run(async_main())
+
+if __name__ == "__main__":
+    main()

--- a/all-phases/all-phases-aidlc-mcp/tests/test_flows.py
+++ b/all-phases/all-phases-aidlc-mcp/tests/test_flows.py
@@ -1,0 +1,251 @@
+"""Tests for full and abbreviated AI-DLC flows."""
+import json
+import tempfile
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from aidlc_mcp.server import (
+    get_next_phase, get_flow_type, detect_project_state, has_existing_code,
+    PHASE_SEQUENCE_FULL, PHASE_SEQUENCE_ABBREVIATED,
+    start_project, get_next_phase_tool, update_phase, get_prompt
+)
+from aidlc_mcp.prompts import PROMPTS
+
+
+# --- Phase Sequence Tests ---
+
+class TestPhaseSequences:
+    def test_full_sequence_length(self):
+        assert len(PHASE_SEQUENCE_FULL) == 6
+
+    def test_abbreviated_sequence_length(self):
+        assert len(PHASE_SEQUENCE_ABBREVIATED) == 5
+
+    def test_full_sequence_order(self):
+        expected = [
+            "discovery-0.1", "inception-1.1", "inception-1.2",
+            "construction-2.1", "construction-2.2", "construction-2.3"
+        ]
+        assert PHASE_SEQUENCE_FULL == expected
+
+    def test_abbreviated_sequence_order(self):
+        expected = [
+            "discovery-0.1-lite", "inception-1.1-lite",
+            "construction-2.2-lite", "operations-3.1", "deployment-2.3-lite"
+        ]
+        assert PHASE_SEQUENCE_ABBREVIATED == expected
+
+
+# --- get_next_phase Tests ---
+
+class TestGetNextPhase:
+    def test_full_flow_progression(self):
+        """Walk through entire full flow."""
+        phase = PHASE_SEQUENCE_FULL[0]
+        visited = [phase]
+        while True:
+            nxt = get_next_phase(phase, "full")
+            if nxt is None:
+                break
+            visited.append(nxt)
+            phase = nxt
+        assert visited == PHASE_SEQUENCE_FULL
+
+    def test_abbreviated_flow_progression(self):
+        """Walk through entire abbreviated flow."""
+        phase = PHASE_SEQUENCE_ABBREVIATED[0]
+        visited = [phase]
+        while True:
+            nxt = get_next_phase(phase, "abbreviated")
+            if nxt is None:
+                break
+            visited.append(nxt)
+            phase = nxt
+        assert visited == PHASE_SEQUENCE_ABBREVIATED
+
+    def test_full_last_phase_returns_none(self):
+        assert get_next_phase("construction-2.3", "full") is None
+
+    def test_abbreviated_last_phase_returns_none(self):
+        assert get_next_phase("deployment-2.3-lite", "abbreviated") is None
+
+    def test_invalid_phase_returns_none(self):
+        assert get_next_phase("nonexistent", "full") is None
+        assert get_next_phase("nonexistent", "abbreviated") is None
+
+    def test_default_flow_type_is_full(self):
+        assert get_next_phase("discovery-0.1") == "inception-1.1"
+
+
+# --- Prompt Mapping Tests ---
+
+class TestPrompts:
+    def test_all_full_phases_have_prompts(self):
+        for phase in PHASE_SEQUENCE_FULL:
+            assert phase in PROMPTS, f"Missing prompt for full phase: {phase}"
+
+    def test_all_abbreviated_phases_have_prompts(self):
+        for phase in PHASE_SEQUENCE_ABBREVIATED:
+            assert phase in PROMPTS, f"Missing prompt for abbreviated phase: {phase}"
+
+    def test_abbreviated_prompts_have_plan_review_execute(self):
+        """Every abbreviated prompt must include plan/review/execute pattern."""
+        for phase in PHASE_SEQUENCE_ABBREVIATED:
+            prompt = PROMPTS[phase]
+            assert "plan" in prompt.lower(), f"{phase} missing plan step"
+            assert "approval" in prompt.lower(), f"{phase} missing approval gate"
+            assert "checkboxes" in prompt.lower(), f"{phase} missing checkbox tracking"
+
+    def test_prompts_have_use_case_or_feature_placeholder(self):
+        """Prompts that need context should have substitution variables."""
+        for phase in ["discovery-0.1-lite", "inception-1.1-lite"]:
+            assert "{use-case}" in PROMPTS[phase], f"{phase} missing {{use-case}} placeholder"
+
+    def test_abbreviated_prompts_reference_previous_phases(self):
+        """Later abbreviated phases should reference earlier phase artifacts."""
+        assert "targeted_analysis.md" in PROMPTS["inception-1.1-lite"]
+        assert "targeted_analysis.md" in PROMPTS["construction-2.2-lite"]
+        assert "user_stories.md" in PROMPTS["construction-2.2-lite"]
+        assert "changes_summary.md" in PROMPTS["operations-3.1"]
+        assert "validation_report.md" in PROMPTS["deployment-2.3-lite"]
+
+
+# --- get_flow_type Tests ---
+
+class TestGetFlowType:
+    def test_defaults_to_full_when_no_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            assert get_flow_type(tmp) == "full"
+
+    def test_reads_full_from_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            aidlc = os.path.join(tmp, ".aidlc")
+            os.makedirs(aidlc)
+            with open(os.path.join(aidlc, "current_phase.json"), "w") as f:
+                json.dump({"currentPhase": "inception-1.1", "flowType": "full"}, f)
+            assert get_flow_type(tmp) == "full"
+
+    def test_reads_abbreviated_from_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            aidlc = os.path.join(tmp, ".aidlc")
+            os.makedirs(aidlc)
+            with open(os.path.join(aidlc, "current_phase.json"), "w") as f:
+                json.dump({"currentPhase": "discovery-0.1-lite", "flowType": "abbreviated"}, f)
+            assert get_flow_type(tmp) == "abbreviated"
+
+    def test_defaults_to_full_when_missing_key(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            aidlc = os.path.join(tmp, ".aidlc")
+            os.makedirs(aidlc)
+            with open(os.path.join(aidlc, "current_phase.json"), "w") as f:
+                json.dump({"currentPhase": "inception-1.1"}, f)
+            assert get_flow_type(tmp) == "full"
+
+
+# --- start_project Integration Tests ---
+
+class TestStartProject:
+    @pytest.mark.asyncio
+    async def test_greenfield_auto_gets_full_flow(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            result = await start_project({"projectPath": tmp, "useCase": "build a task app"})
+            text = result[0].text
+            assert "Full AI-DLC" in text
+            assert "inception-1.1" in text
+            with open(os.path.join(tmp, ".aidlc", "current_phase.json")) as f:
+                data = json.load(f)
+            assert data["flowType"] == "full"
+
+    @pytest.mark.asyncio
+    async def test_brownfield_auto_gets_full_flow(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            # Create a source file to make it brownfield
+            os.makedirs(os.path.join(tmp, "src"))
+            with open(os.path.join(tmp, "src", "main.py"), "w") as f:
+                f.write("print('hello')")
+            result = await start_project({"projectPath": tmp, "useCase": "fix login bug"})
+            text = result[0].text
+            assert "Full AI-DLC" in text
+            assert "discovery-0.1" in text
+            with open(os.path.join(tmp, ".aidlc", "current_phase.json")) as f:
+                data = json.load(f)
+            assert data["flowType"] == "full"
+
+    @pytest.mark.asyncio
+    async def test_brownfield_override_to_full(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            os.makedirs(os.path.join(tmp, "src"))
+            with open(os.path.join(tmp, "src", "main.py"), "w") as f:
+                f.write("print('hello')")
+            result = await start_project({"projectPath": tmp, "useCase": "major new feature", "flowType": "full"})
+            text = result[0].text
+            assert "Full AI-DLC" in text
+            assert "discovery-0.1" in text
+            # Should NOT be the lite version
+            assert "lite" not in text
+
+    @pytest.mark.asyncio
+    async def test_greenfield_override_to_abbreviated(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            result = await start_project({"projectPath": tmp, "useCase": "quick prototype", "flowType": "abbreviated"})
+            text = result[0].text
+            assert "Abbreviated" in text
+
+
+# --- Phase Update Preserves Flow Type ---
+
+class TestUpdatePhasePreservesFlow:
+    @pytest.mark.asyncio
+    async def test_flow_type_preserved_after_phase_update(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            # Init as abbreviated
+            await start_project({"projectPath": tmp, "useCase": "fix bug", "flowType": "abbreviated"})
+            # Update phase
+            await update_phase({"projectPath": tmp, "phase": "inception-1.1-lite-ready"})
+            with open(os.path.join(tmp, ".aidlc", "current_phase.json")) as f:
+                data = json.load(f)
+            assert data["flowType"] == "abbreviated"
+            assert data["currentPhase"] == "inception-1.1-lite-ready"
+
+
+# --- get_next_phase_tool Integration ---
+
+class TestGetNextPhaseTool:
+    @pytest.mark.asyncio
+    async def test_abbreviated_flow_next_phase(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            await start_project({"projectPath": tmp, "useCase": "fix bug", "flowType": "abbreviated"})
+            result = await get_next_phase_tool({"projectPath": tmp})
+            text = result[0].text
+            assert "inception-1.1-lite" in text
+            assert "abbreviated" in text
+
+    @pytest.mark.asyncio
+    async def test_full_flow_next_phase(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            await start_project({"projectPath": tmp, "useCase": "new app", "flowType": "full"})
+            result = await get_next_phase_tool({"projectPath": tmp})
+            text = result[0].text
+            assert "inception-1.2" in text or "inception-1.1" in text
+            assert "full" in text
+
+
+# --- get_prompt Tests ---
+
+class TestGetPrompt:
+    @pytest.mark.asyncio
+    async def test_abbreviated_prompt_returns_content(self):
+        result = await get_prompt({"phase": "discovery-0.1-lite", "useCase": "fix timeout bug"})
+        text = result[0].text
+        assert "targeted analysis" in text.lower()
+        assert "fix timeout bug" in text
+
+    @pytest.mark.asyncio
+    async def test_full_prompt_returns_content(self):
+        result = await get_prompt({"phase": "inception-1.1", "useCase": "build task app"})
+        text = result[0].text
+        assert "user stories" in text.lower()
+        assert "build task app" in text

--- a/all-phases/all-phases-aidlc-mcp/tests/test_security.py
+++ b/all-phases/all-phases-aidlc-mcp/tests/test_security.py
@@ -1,0 +1,147 @@
+"""Tests for security validations added by threat remediation."""
+import json
+import tempfile
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from aidlc_mcp.server import (
+    validate_project_path, validate_plan_file_path, sanitize_use_case,
+    validate_required_string, detect_current_phase, get_flow_type,
+    PHASE_SEQUENCE_FULL, PHASE_SEQUENCE_ABBREVIATED,
+)
+
+
+class TestValidateProjectPath:
+    def test_rejects_path_traversal(self, tmp_path):
+        with pytest.raises(ValueError, match="path traversal"):
+            validate_project_path(str(tmp_path / ".." / "etc"), must_exist=False)
+
+    def test_rejects_empty_string(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            validate_project_path("")
+
+    def test_rejects_non_string(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            validate_project_path(None)
+
+    def test_rejects_nonexistent_path(self):
+        with pytest.raises(ValueError, match="does not exist"):
+            validate_project_path("/nonexistent/path/abc123")
+
+    def test_rejects_file_path(self, tmp_path):
+        f = tmp_path / "file.txt"
+        f.write_text("hi")
+        with pytest.raises(ValueError, match="not a directory"):
+            validate_project_path(str(f))
+
+    def test_accepts_valid_directory(self, tmp_path):
+        result = validate_project_path(str(tmp_path))
+        assert result == str(tmp_path.resolve())
+
+    def test_accepts_nonexistent_when_must_exist_false(self, tmp_path):
+        p = str(tmp_path / "newproject")
+        result = validate_project_path(p, must_exist=False)
+        assert "newproject" in result
+
+
+class TestValidatePlanFilePath:
+    def test_rejects_path_outside_aidlc(self, tmp_path):
+        f = tmp_path / "plan.md"
+        f.write_text("plan")
+        with pytest.raises(ValueError, match=".aidlc"):
+            validate_plan_file_path(str(f))
+
+    def test_rejects_traversal(self, tmp_path):
+        with pytest.raises(ValueError, match="path traversal"):
+            validate_plan_file_path(str(tmp_path / ".aidlc" / ".." / "plan.md"))
+
+    def test_accepts_valid_aidlc_path(self, tmp_path):
+        aidlc = tmp_path / ".aidlc" / "feature"
+        aidlc.mkdir(parents=True)
+        f = aidlc / "plan.md"
+        f.write_text("plan")
+        result = validate_plan_file_path(str(f))
+        assert ".aidlc" in result
+
+
+class TestSanitizeUseCase:
+    def test_strips_control_characters(self):
+        text, truncated = sanitize_use_case("hello\x00world\x07test")
+        assert text == "helloworldtest"
+        assert not truncated
+
+    def test_truncates_at_limit(self):
+        text, truncated = sanitize_use_case("a" * 1500)
+        assert len(text) == 1000
+        assert truncated
+
+    def test_no_truncation_under_limit(self):
+        text, truncated = sanitize_use_case("short use case")
+        assert text == "short use case"
+        assert not truncated
+
+    def test_handles_non_string(self):
+        text, truncated = sanitize_use_case(123)
+        assert text == ""
+        assert not truncated
+
+    def test_preserves_unicode(self):
+        text, _ = sanitize_use_case("日本語テスト")
+        assert text == "日本語テスト"
+
+
+class TestValidateRequiredString:
+    def test_rejects_missing_key(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            validate_required_string({}, "key")
+
+    def test_rejects_empty_string(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            validate_required_string({"key": ""}, "key")
+
+    def test_rejects_non_string(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            validate_required_string({"key": 123}, "key")
+
+    def test_accepts_valid_string(self):
+        assert validate_required_string({"key": "value"}, "key") == "value"
+
+
+class TestPhaseStateValidation:
+    def test_detect_rejects_invalid_phase(self, tmp_path):
+        aidlc = tmp_path / ".aidlc"
+        aidlc.mkdir()
+        phase_file = aidlc / "current_phase.json"
+        phase_file.write_text(json.dumps({"currentPhase": "invalid-phase", "flowType": "full"}))
+        assert detect_current_phase(str(tmp_path)) is None
+
+    def test_detect_rejects_missing_currentPhase(self, tmp_path):
+        aidlc = tmp_path / ".aidlc"
+        aidlc.mkdir()
+        phase_file = aidlc / "current_phase.json"
+        phase_file.write_text(json.dumps({"flowType": "full"}))
+        assert detect_current_phase(str(tmp_path)) is None
+
+    def test_detect_accepts_valid_phase(self, tmp_path):
+        aidlc = tmp_path / ".aidlc"
+        aidlc.mkdir()
+        phase_file = aidlc / "current_phase.json"
+        phase_file.write_text(json.dumps({"currentPhase": "discovery-0.1", "flowType": "full"}))
+        assert detect_current_phase(str(tmp_path)) == "discovery-0.1"
+
+    def test_detect_accepts_ready_variant(self, tmp_path):
+        aidlc = tmp_path / ".aidlc"
+        aidlc.mkdir()
+        phase_file = aidlc / "current_phase.json"
+        phase_file.write_text(json.dumps({"currentPhase": "inception-1.1-ready", "flowType": "full"}))
+        assert detect_current_phase(str(tmp_path)) == "inception-1.1-ready"
+
+    def test_get_flow_type_rejects_invalid(self, tmp_path):
+        aidlc = tmp_path / ".aidlc"
+        aidlc.mkdir()
+        phase_file = aidlc / "current_phase.json"
+        phase_file.write_text(json.dumps({"currentPhase": "discovery-0.1", "flowType": "hacked"}))
+        assert get_flow_type(str(tmp_path)) == "full"  # falls back to default


### PR DESCRIPTION
## Summary

Adds a Python MCP server pattern that implements the AI-DLC methodology as structured tool calls. This is a **complementary approach** to the rules-based [awslabs/aidlc-workflows](https://github.com/awslabs/aidlc-workflows) — not a replacement.

AppSec approved.

### What it does

- **7 MCP tools**: `start_project`, `get_next_phase`, `get_phase_prompt`, `set_phase_status`, `update_project_plan`, `request_phase_approval`, `integrate_code`
- **Full & abbreviated flows**: Full cycle for complex features (all phases from inception through deployment); abbreviated for bug fixes and minor enhancements (streamlined phases, no unit decomposition or domain modeling). Greenfield projects use the full flow; Brownfield defaults to abbreviated but can be overridden to full via `flowType` for major features
- **Server-enforced phase gates** instead of agent interpretation of markdown rules
- **Cross-session state persistence** via `current_phase.json`
- **Centralized prompt customization** in a single `prompts.py` module
- **Security hardened**: path traversal prevention, input sanitization, error sanitization, symlink rejection, resource limits, pinned dependency
- **Tool agnostic**: Works with any MCP-compatible client (Kiro CLI, Q CLI, Claude Desktop, Cursor, Cline, etc.)

### Why both approaches exist

| | aidlc-workflows (rules) | This pattern (MCP server) |
|---|---|---|
| Phase enforcement | Agent interprets markdown | Server validates programmatically |
| Cross-session state | Agent re-reads rules | Persistent JSON state |
| Prompt customization | Edit scattered markdown files | Single Python module |
| Dependencies | None | Python 3.10+, mcp package |

### Pattern location

`all-phases/all-phases-aidlc-mcp/`